### PR TITLE
Modify translation units for Nearby page

### DIFF
--- a/assets/enroute_cz.ts
+++ b/assets/enroute_cz.ts
@@ -979,15 +979,15 @@
     </message>
 </context>
 <context>
-    <name>NearbyAirfields</name>
+    <name>Nearby</name>
     <message>
-        <location filename="../../enroute/src/qml/pages/NearbyAirfields.qml" line="31"/>
-        <source>Nearby Airfields</source>
+        <location filename="../../enroute/src/qml/pages/Nearby.qml" line="31"/>
+        <source>Nearby</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../enroute/src/qml/pages/NearbyAirfields.qml" line="92"/>
-        <source>&lt;h3&gt;Sorry!&lt;/h3&gt;&lt;p&gt;No airfields available. Please make sure that an aviation map is installed.&lt;/p&gt;</source>
+        <location filename="../../enroute/src/qml/pages/Nearby.qml" line="92"/>
+        <source>&lt;h3&gt;Sorry!&lt;/h3&gt;&lt;p&gt;No data available. Please make sure that an aviation map is installed.&lt;/p&gt;</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/assets/enroute_de.ts
+++ b/assets/enroute_de.ts
@@ -1181,16 +1181,16 @@
     </message>
 </context>
 <context>
-    <name>NearbyAirfields</name>
+    <name>Nearby</name>
     <message>
-        <location filename="../../enroute/src/qml/pages/NearbyAirfields.qml" line="31"/>
-        <source>Nearby Airfields</source>
-        <translation>Nächstgelegene Flugplätze</translation>
+        <location filename="../../enroute/src/qml/pages/Nearby.qml" line="31"/>
+        <source>Nearby</source>
+        <translation>Nächstgelegene</translation>
     </message>
     <message>
-        <location filename="../../enroute/src/qml/pages/NearbyAirfields.qml" line="92"/>
-        <source>&lt;h3&gt;Sorry!&lt;/h3&gt;&lt;p&gt;No airfields available. Please make sure that an aviation map is installed.&lt;/p&gt;</source>
-        <translation>&lt;h3&gt;Sorry!&lt;/h3&gt;&lt;p&gt;Keine Flugplätze verfügbar. Bitte installieren Sie eine Luftfahrtkarte.&lt;/p&gt;</translation>
+        <location filename="../../enroute/src/qml/pages/Nearby.qml" line="92"/>
+        <source>&lt;h3&gt;Sorry!&lt;/h3&gt;&lt;p&gt;No data available. Please make sure that an aviation map is installed.&lt;/p&gt;</source>
+        <translation>&lt;h3&gt;Sorry!&lt;/h3&gt;&lt;p&gt;Keine Daten verfügbar. Bitte installieren Sie eine Luftfahrtkarte.&lt;/p&gt;</translation>
     </message>
 </context>
 <context>


### PR DESCRIPTION
This PR is linked to [enroute PR 47](https://github.com/Akaflieg-Freiburg/enroute/pull/47). It adapts the translations for the new nearby page.

Note that I do not speak German, so please double check my translations.