### PR TITLE
Add form factors to desktop and appdata files

### DIFF
--- a/desktop/linux/de.akaflieg_freiburg.enroute.appdata.xml.in
+++ b/desktop/linux/de.akaflieg_freiburg.enroute.appdata.xml.in
@@ -61,4 +61,8 @@
   <provides>
     <binary>${PROJECT_NAME}</binary>
   </provides>
+  <custom>
+    <value key="Purism::form_factor">workstation</value>
+    <value key="Purism::form_factor">mobile</value>
+  </custom>
 </component>

--- a/desktop/linux/de.akaflieg_freiburg.enroute.desktop.in
+++ b/desktop/linux/de.akaflieg_freiburg.enroute.desktop.in
@@ -15,3 +15,4 @@ Exec=${PROJECT_NAME}
 Terminal=false
 MimeType=application/geo+json;application/gpx+xml;
 Categories=Utility;Maps;
+X-Purism-FormFactor=Workstation;Mobile;


### PR DESCRIPTION
This makes the app visible in the PureOS Store on the Librem 5.

See https://puri.sm/posts/specify-form-factors-in-your-librem-5-apps/